### PR TITLE
chore: modernize install scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,99 @@
-![ps](https://github.com/dieterpl/prime-shell-bundle/raw/master/ps.png)
+# zsh-config-bundle
 
-This is a shell bundle based on oh-my-zsh for macOS and Ubuntu. This is a complete ready to use bundle optimized for performance and usability.
+A one-command zsh setup based on oh-my-zsh. Installs a curated set of modern CLI tools, configures the shell with sane defaults, and gets you productive in under 5 minutes.
 
-# Features
+![preview](https://github.com/dieterpl/zsh-config-bundle/raw/master/ps.png)
 
-The scripts automatically downloads and installs the following tools:
+---
 
-- oh-my-zsh: https://github.com/robbyrussell/oh-my-zsh
-- Exa: https://github.com/ogham/exa
-- fasd: https://github.com/clvv/fasd
-- micro: https://github.com/zyedidia/micro
-- fzf: https://github.com/junegunn/fzfx
-- zsh-autosuggestions: https://github.com/zsh-users/zsh-autosuggestions
+## What you get
 
-Furthermore a few handy aliases are created, check .zshrc or install.sh
+### Tools
 
-# Install
+| Tool | Description |
+|------|-------------|
+| [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) | zsh framework with the `muse` theme |
+| [fzf](https://github.com/junegunn/fzf) | Fuzzy finder — powers history search, file picker, and more |
+| [eza](https://github.com/eza-community/eza) | Modern `ls` with colours, icons, and git status |
+| [zoxide](https://github.com/ajeetdsouza/zoxide) | Smart `cd` that learns your most-used directories |
+| [bat](https://github.com/sharkdp/bat) | Syntax-highlighted `cat` with line numbers |
+| [fd](https://github.com/sharkdp/fd) | Fast, user-friendly alternative to `find` |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) | Fast, modern `grep` |
+| [micro](https://github.com/zyedidia/micro) | Intuitive terminal text editor |
+| [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) | Fish-style inline command suggestions |
 
-To install download the install script or use curl:
+### Aliases
 
-## MacOs
+| Alias | Expands to | Description |
+|-------|-----------|-------------|
+| `l` | `eza -luabgU --git --time-style=relative -s type` | Detailed file listing with git status |
+| `t` | `tree -C -h` | Coloured directory tree |
+| `m` | `micro` | Open micro editor |
+| `c` | `z` | Jump to a directory (zoxide) |
+| `fh` | `find . -name` | Find a file by name |
+| `mm` | `fzf` → `micro` | Pick a file with fzf preview, open in micro |
+| `mmm` | `fd` + `fzf` → `micro` | Search all files with fd, pick with fzf, open in micro |
 
-`sh -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installMac.sh)"`
+### Key bindings (fzf)
 
-## Ubuntu
+| Key | Action |
+|-----|--------|
+| `Ctrl+R` | Fuzzy search shell history |
+| `Ctrl+T` | Fuzzy search files in the current directory tree |
+| `Alt+C` | Fuzzy jump into a subdirectory |
 
-`sh -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installUbuntu.sh)"`
+---
 
+## Requirements
 
-## Arch
+- `bash`, `curl`, `git`
+- **macOS**: Xcode Command Line Tools (`xcode-select --install`) — Homebrew will be installed automatically if missing
+- **Ubuntu / Arch**: `sudo` access
 
-`sh -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installArch.sh)"`
+---
 
+## Install
+
+### macOS
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installMac.sh)"
+```
+
+### Ubuntu
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installUbuntu.sh)"
+```
+
+**Silent mode** (skips `chsh` — useful in containers or environments where changing the default shell requires no interaction):
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installUbuntuSilent.sh)"
+```
+
+### Arch Linux
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/dieterpl/zsh-config-bundle/master/installArch.sh)"
+```
+
+---
+
+## After install
+
+Reload your shell to apply everything:
+
+```bash
+exec zsh
+```
+
+Quick smoke tests:
+
+```bash
+z --version          # zoxide working
+eza --version        # eza working
+echo $EDITOR         # should print: micro
+```
+
+Then try the key bindings: `Ctrl+R` for history search, `Ctrl+T` to pick a file.

--- a/installArch.sh
+++ b/installArch.sh
@@ -1,12 +1,11 @@
-#!/bin/sh
-colorPrint(){
-    printf "${BLUE}"
-    echo "$1"
-    printf "${NORMAL}"
-}
-colorSetup(){
-      if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
+#!/bin/bash
+set -e
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+
+colorSetup() {
+  if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
   fi
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
     RED="$(tput setaf 1)"
@@ -16,77 +15,117 @@ colorSetup(){
     BOLD="$(tput bold)"
     NORMAL="$(tput sgr0)"
   else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    BOLD=""
-    NORMAL=""
+    RED="" GREEN="" YELLOW="" BLUE="" BOLD="" NORMAL=""
   fi
 }
 
-colorSetup
-colorPrint "Backing up zshrc"
-if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ~/.zshrc.backup${NORMAL}\n";
-    mv ~/.zshrc ~/.zshrc.backup;
-fi
-# Install Brew
-# Install apps
-colorPrint "Installing Git ..."
-sudo pacman -Sy --noconfirm install git
-colorPrint "Installing ZSH ..."
-sudo pacman -Sy --noconfirm install zsh
-colorPrint "Installing tree ..."
-sudo pacman -Sy --noconfirm install tree
-colorPrint "Installing exa ..."
-curl -Lo exa.zip "https://github.com/ogham/exa/releases/download/v0.8.0/exa-linux-x86_64-0.8.0.zip"
-unzip -o exa.zip -d "./"
-rm -f exa.zip
-sudo mv exa-linux-x86_64 /usr/bin/exa
-rm -rf exa-linux-x86_64
-colorPrint "Installing fasd ..."
-curl -Lo fasd.zip "https://github.com/clvv/fasd/zipball/1.0.1"
-unzip -o fasd.zip -d "./"
-rm -f fasd.zip
-sudo mv clvv-fasd-4822024/fasd /usr/bin/fasd
-rm -rf clvv-fasd-4822024
-colorPrint "Installing micro ..."
-curl https://getmic.ro | bash
-sudo mv micro /usr/bin/micro
+info()    { printf "${BLUE}  →  %s${NORMAL}\n" "$1"; }
+success() { printf "${GREEN}  ✓  %s${NORMAL}\n" "$1"; }
+warn()    { printf "${YELLOW}  !  %s${NORMAL}\n" "$1"; }
+error()   { printf "${RED}  ✗  %s${NORMAL}\n" "$1" >&2; }
 
-#$(brew --prefix)/opt/fzf/install < dev/null
-# Install oh-my-zsh
-colorPrint "Installing oh-my-zsh ..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" < /dev/null
-export ZSH=~/.oh-my-zsh
-cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
-# Set Theme
-colorPrint "Setting Theme"
-sed 's,ZSH_THEME=[^;]*,ZSH_THEME=muse,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-# Add plugins
-colorPrint "Installing fzf ..."
-git clone https://github.com/junegunn/fzf.git ~/.oh-my-zsh/custom/plugins/fzf
-~/.oh-my-zsh/custom/plugins/fzf/install
-colorPrint "Install plugins"
-git clone https://github.com/Treri/fzf-zsh.git ~/.oh-my-zsh/custom/plugins/fzf-zsh
-git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/plugins/zsh-autosuggestions
-sed 's,^plugins=(,plugins=(git gitfast mvn fzf-zsh docker last-working-dir colored-man-pages colorize, ' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-echo "eval \"\$(fasd --init auto zsh-hook zsh-ccomp zsh-ccomp-install zsh-wcomp zsh-wcomp-install)\"" >> ~/.zshrc
-# Add aliases
-colorPrint "Set Aliases"
-echo "export ZSH=~/.oh-my-zsh"  >> ~/.zshrc
-echo "export EDITOR=micro" >> ~/.zshrc
-echo "alias fh=\"find . -name\"" >> ~/.zshrc
-echo "alias t=\"tree -C -h\"" >> ~/.zshrc
-echo "alias m=\"micro\"" >> ~/.zshrc
-echo "alias l=\"exa -luabgU --git --time-style default -s type\"" >> ~/.zshrc
-echo "alias c=\"fasd_cd -d\"" >> ~/.zshrc
-echo "alias mm=\"fasd -e micro --f\"" >> ~/.zshrc
-echo "alias mmm\"fasd -e micro -i\"" >> ~/.zshrc
-colorPrint "Changing Shell (admin)"
-chsh -s $(which zsh)
+# ── Step functions ────────────────────────────────────────────────────────────
+
+backupZshrc() {
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+    warn "Existing ~/.zshrc found — backing up to ~/.zshrc.backup"
+    mv ~/.zshrc ~/.zshrc.backup
+  fi
+}
+
+installPackages() {
+  info "Installing packages via pacman"
+  sudo pacman -Sy --noconfirm git zsh tree fzf eza zoxide bat fd ripgrep
+
+  info "Installing micro"
+  curl https://getmic.ro | bash
+  sudo mv micro /usr/local/bin/micro
+  success "micro installed"
+}
+
+installOhMyZsh() {
+  export ZSH="$HOME/.oh-my-zsh"
+  info "Installing oh-my-zsh"
+  RUNZSH=no CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  success "oh-my-zsh installed"
+}
+
+installPlugins() {
+  local target="${ZSH}/custom/plugins/zsh-autosuggestions"
+  if [[ -d "$target" ]]; then
+    warn "zsh-autosuggestions already cloned — skipping"
+  else
+    info "Cloning zsh-autosuggestions"
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$target"
+    success "zsh-autosuggestions cloned"
+  fi
+}
+
+configureZshrc() {
+  info "Setting theme to muse"
+  sed 's,ZSH_THEME=[^;]*,ZSH_THEME="muse",' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Setting plugins"
+  sed 's,^plugins=(.*,plugins=(git fzf zoxide zsh-autosuggestions colored-man-pages colorize last-working-dir),' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Appending custom config"
+  cat >> ~/.zshrc << 'ZSHRC_EOF'
+
+# ── Custom config ─────────────────────────────────────────────────────────────
+
+export ZSH="$HOME/.oh-my-zsh"
+export EDITOR=micro
+
+alias fh='find . -name'
+alias t='tree -C -h'
+alias m='micro'
+alias l='eza -luabgU --git --time-style=relative -s type'
+alias c='z'
+alias mm='micro "$(fzf --preview="bat --color=always {}")"'
+alias mmm='micro "$(fd --type f | fzf --preview="bat --color=always {}")"'
+ZSHRC_EOF
+
+  success ".zshrc configured"
+}
+
+changeDefaultShell() {
+  if [[ "$(basename "$SHELL")" == "zsh" ]]; then
+    info "zsh is already the default shell — skipping"
+  else
+    info "Changing default shell to zsh (may prompt for password)"
+    chsh -s "$(which zsh)"
+    success "Default shell changed to zsh"
+  fi
+}
+
+verify() {
+  printf "\n${BOLD}── Verification ───────────────────────────────────────────${NORMAL}\n"
+  local pass=0 fail=0
+  check_cmd() {
+    if command -v "$1" &>/dev/null; then success "$1"; ((pass++))
+    else error "$1 not found"; ((fail++)); fi
+  }
+  check_cmd zsh; check_cmd eza; check_cmd zoxide; check_cmd fzf
+  check_cmd micro; check_cmd bat; check_cmd fd; check_cmd rg
+
+  [[ -d "$HOME/.oh-my-zsh" ]] && { success "oh-my-zsh exists"; ((pass++)); } || { error "oh-my-zsh missing"; ((fail++)); }
+  [[ -d "${ZSH}/custom/plugins/zsh-autosuggestions" ]] && { success "zsh-autosuggestions cloned"; ((pass++)); } || { error "zsh-autosuggestions missing"; ((fail++)); }
+
+  printf "\n${BOLD}%d passed, %d failed${NORMAL}\n" "$pass" "$fail"
+  printf "\n${BOLD}Run: exec zsh${NORMAL} to apply all changes\n"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+colorSetup
+printf "\n${BOLD}── zsh-config-bundle installer (Arch Linux) ────────────────${NORMAL}\n\n"
+
+backupZshrc
+installPackages
+installOhMyZsh
+installPlugins
+configureZshrc
+changeDefaultShell
+verify

--- a/installMac.sh
+++ b/installMac.sh
@@ -1,12 +1,11 @@
-#!/bin/sh
-colorPrint(){
-    printf "${BLUE}"
-    echo "$1"
-    printf "${NORMAL}"
-}
-colorSetup(){
-      if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
+#!/bin/bash
+set -e
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+
+colorSetup() {
+  if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
   fi
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
     RED="$(tput setaf 1)"
@@ -16,76 +15,174 @@ colorSetup(){
     BOLD="$(tput bold)"
     NORMAL="$(tput sgr0)"
   else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    BOLD=""
-    NORMAL=""
+    RED="" GREEN="" YELLOW="" BLUE="" BOLD="" NORMAL=""
   fi
 }
-installBrew(){
-    which -s brew
-    if [[ $? != 0 ]] ; then
-        # Install Homebrew
-        colorPrint "Installing Brew"
-        ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null
-    else
-        colorPrint "Brew already installed"
-        brew update
-    fi
+
+info()    { printf "${BLUE}  →  %s${NORMAL}\n" "$1"; }
+success() { printf "${GREEN}  ✓  %s${NORMAL}\n" "$1"; }
+warn()    { printf "${YELLOW}  !  %s${NORMAL}\n" "$1"; }
+error()   { printf "${RED}  ✗  %s${NORMAL}\n" "$1" >&2; }
+
+# ── Step functions ────────────────────────────────────────────────────────────
+
+backupZshrc() {
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+    warn "Existing ~/.zshrc found — backing up to ~/.zshrc.backup"
+    mv ~/.zshrc ~/.zshrc.backup
+  fi
 }
-colorSetup
-colorPrint "Backing up zshrc"
-if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ~/.zshrc.backup${NORMAL}\n";
-    mv ~/.zshrc ~/.zshrc.backup;
+
+installBrew() {
+  if which -s brew; then
+    info "Homebrew already installed — updating"
+    brew update
+  else
+    info "Installing Homebrew"
+    bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
+  # Make brew available in the current session (required on Apple Silicon)
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
+}
+
+installPackages() {
+  local packages=(zsh tree micro fzf eza zoxide bat fd ripgrep)
+  for pkg in "${packages[@]}"; do
+    info "Installing $pkg"
+    brew install "$pkg"
+    success "$pkg installed"
+  done
+}
+
+installOhMyZsh() {
+  export ZSH="$HOME/.oh-my-zsh"
+  info "Installing oh-my-zsh"
+  RUNZSH=no CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  success "oh-my-zsh installed"
+}
+
+installPlugins() {
+  local target="${ZSH}/custom/plugins/zsh-autosuggestions"
+  if [[ -d "$target" ]]; then
+    warn "zsh-autosuggestions already cloned — skipping"
+  else
+    info "Cloning zsh-autosuggestions"
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$target"
+    success "zsh-autosuggestions cloned"
+  fi
+}
+
+configureZshrc() {
+  info "Setting theme to muse"
+  sed 's,ZSH_THEME=[^;]*,ZSH_THEME="muse",' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Setting plugins"
+  sed 's,^plugins=(.*,plugins=(git brew fzf zoxide zsh-autosuggestions colored-man-pages colorize last-working-dir iterm2),' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Appending custom config"
+  cat >> ~/.zshrc << 'ZSHRC_EOF'
+
+# ── Custom config ─────────────────────────────────────────────────────────────
+
+# Homebrew (Apple Silicon — no-op on Intel where /usr/local/bin is already in PATH)
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
-# Install Brew
+
+export EDITOR=micro
+
+alias fh='find . -name'
+alias t='tree -C -h'
+alias m='micro'
+alias l='eza -luabgU --git --time-style=relative -s type'
+alias c='z'
+alias mm='micro "$(fzf --preview="bat --color=always {}")"'
+alias mmm='micro "$(fd --type f | fzf --preview="bat --color=always {}")"'
+ZSHRC_EOF
+
+  success ".zshrc configured"
+}
+
+changeDefaultShell() {
+  if [[ "$(basename "$SHELL")" == "zsh" ]]; then
+    info "zsh is already the default shell — skipping"
+  else
+    info "Changing default shell to zsh (may prompt for password)"
+    chsh -s "$(which zsh)"
+    success "Default shell changed to zsh"
+  fi
+}
+
+verify() {
+  printf "\n${BOLD}── Verification ───────────────────────────────────────────${NORMAL}\n"
+  local pass=0 fail=0
+  check_cmd() {
+    if command -v "$1" &>/dev/null; then
+      success "$1"
+      ((pass++))
+    else
+      error "$1 not found"
+      ((fail++))
+    fi
+  }
+  check_cmd zsh
+  check_cmd eza
+  check_cmd zoxide
+  check_cmd fzf
+  check_cmd micro
+  check_cmd bat
+  check_cmd fd
+  check_cmd rg
+
+  if [[ -d "$HOME/.oh-my-zsh" ]]; then
+    success "oh-my-zsh directory exists"
+    ((pass++))
+  else
+    error "oh-my-zsh directory missing"
+    ((fail++))
+  fi
+
+  if [[ -d "${ZSH}/custom/plugins/zsh-autosuggestions" ]]; then
+    success "zsh-autosuggestions cloned correctly"
+    ((pass++))
+  else
+    error "zsh-autosuggestions missing from custom/plugins"
+    ((fail++))
+  fi
+
+  if grep -q "plugins=(" ~/.zshrc && grep -q "fzf" ~/.zshrc; then
+    success ".zshrc plugins line looks correct"
+    ((pass++))
+  else
+    warn ".zshrc plugins line may need review"
+  fi
+
+  printf "\n${BOLD}%d passed, %d failed${NORMAL}\n" "$pass" "$fail"
+
+  printf "\n${BOLD}── Next steps ──────────────────────────────────────────────${NORMAL}\n"
+  info "Open a new terminal (or run: exec zsh) to apply all changes"
+  info "Ctrl+R — fzf history search"
+  info "Ctrl+T — fzf file search"
+  info "Alt+C  — fzf directory jump"
+  info "l      — eza file listing"
+  info "z <dir> — jump to a directory (zoxide)"
+  info "mm     — open a file in micro via fzf"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+colorSetup
+printf "\n${BOLD}── zsh-config-bundle installer (macOS) ─────────────────────${NORMAL}\n\n"
+
+backupZshrc
 installBrew
-# Install apps
-colorPrint "Installing ZSH ..."
-brew install zsh
-colorPrint "Installing tree ..."
-brew install tree
-colorPrint "Installing exa ..."
-brew install exa
-colorPrint "Installing fasd ..."
-brew install fasd
-colorPrint "Installing micro ..."
-brew install micro
-colorPrint "Installing fzf ..."
-brew install fzf
-#$(brew --prefix)/opt/fzf/install < dev/null
-# Install oh-my-zsh
-export ZSH=~/.oh-my-zsh
-colorPrint "Installing oh-my-zsh ..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" < /dev/null
-cp "$ZSH"/templates/zshrc.zsh-template ~/.zshrc
-# Set Theme
-colorPrint "Setting Theme"
-sed 's,ZSH_THEME=[^;]*,ZSH_THEME=muse,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-# Add plugins
-colorPrint "Install plugins"
-git clone https://github.com/junegunn/fzf.git ${ZSH}/custom/plugins/fzf
-${ZSH}/custom/plugins/fzf/install --bin
-git clone https://github.com/Treri/fzf-zsh.git ${ZSH}/custom/plugins/fzf-zsh
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH}/plugins/zsh-autosuggestions
-sed 's,^plugins=(,plugins=(brew git gitfast mvn zsh-autosuggestions fzf-zsh docker iterm2 last-working-dir colored-man-pages colorize,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-echo "eval \"\$(fasd --init auto zsh-hook zsh-ccomp zsh-ccomp-install zsh-wcomp zsh-wcomp-install)\"" >> ~/.zshrc
-# Add aliases
-colorPrint "Set Aliases"
-echo "export EDITOR = micro" >> ~/.zshrc
-echo "alias fh=\"find . -name\"" >> ~/.zshrc
-echo "alias t=\"tree -C -h\"" >> ~/.zshrc
-echo "alias m=\"micro\"" >> ~/.zshrc
-echo "alias l=\"exa -luabgU --git --time-style default -s type\"" >> ~/.zshrc
-echo "alias c=\"fasd_cd -d\"" >> ~/.zshrc
-echo "alias mm=\"fasd -e micro --f\"" >> ~/.zshrc
-echo "alias mmm\"fasd -e micro -i\"" >> ~/.zshrc
-colorPrint "Changing Shell (admin)"
-chsh -s $(which zsh)
+installPackages
+installOhMyZsh
+installPlugins
+configureZshrc
+changeDefaultShell
+verify

--- a/installUbuntu.sh
+++ b/installUbuntu.sh
@@ -1,12 +1,11 @@
-#!/bin/sh
-colorPrint(){
-    printf "${BLUE}"
-    echo "$1"
-    printf "${NORMAL}"
-}
-colorSetup(){
-      if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
+#!/bin/bash
+set -e
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+
+colorSetup() {
+  if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
   fi
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
     RED="$(tput setaf 1)"
@@ -16,77 +15,156 @@ colorSetup(){
     BOLD="$(tput bold)"
     NORMAL="$(tput sgr0)"
   else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    BOLD=""
-    NORMAL=""
+    RED="" GREEN="" YELLOW="" BLUE="" BOLD="" NORMAL=""
   fi
 }
 
-colorSetup
-colorPrint "Backing up zshrc"
-if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ~/.zshrc.backup${NORMAL}\n";
-    mv ~/.zshrc ~/.zshrc.backup;
-fi
-# Install Brew
-# Install apps
-colorPrint "Installing Git ..."
-sudo apt-get -y install git
-colorPrint "Installing ZSH ..."
-sudo apt-get -y install zsh
-colorPrint "Installing tree ..."
-sudo apt-get -y install tree
-colorPrint "Installing exa ..."
-curl -Lo exa.zip "https://github.com/ogham/exa/releases/download/v0.8.0/exa-linux-x86_64-0.8.0.zip"
-unzip -o exa.zip -d "./"
-rm -f exa.zip
-sudo mv exa-linux-x86_64 /usr/bin/exa
-rm -rf exa-linux-x86_64
-colorPrint "Installing fasd ..."
-curl -Lo fasd.zip "https://github.com/clvv/fasd/zipball/1.0.1"
-unzip -o fasd.zip -d "./"
-rm -f fasd.zip
-sudo mv clvv-fasd-4822024/fasd /usr/bin/fasd
-rm -rf clvv-fasd-4822024
-colorPrint "Installing micro ..."
-curl https://getmic.ro | bash
-sudo mv micro /usr/bin/micro
+info()    { printf "${BLUE}  →  %s${NORMAL}\n" "$1"; }
+success() { printf "${GREEN}  ✓  %s${NORMAL}\n" "$1"; }
+warn()    { printf "${YELLOW}  !  %s${NORMAL}\n" "$1"; }
+error()   { printf "${RED}  ✗  %s${NORMAL}\n" "$1" >&2; }
 
-#$(brew --prefix)/opt/fzf/install < dev/null
-# Install oh-my-zsh
-colorPrint "Installing oh-my-zsh ..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" < /dev/null
-export ZSH=~/.oh-my-zsh
-cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
-# Set Theme
-colorPrint "Setting Theme"
-sed 's,ZSH_THEME=[^;]*,ZSH_THEME=muse,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-# Add plugins
-colorPrint "Installing fzf ..."
-git clone https://github.com/junegunn/fzf.git ~/.oh-my-zsh/custom/plugins/fzf
-~/.oh-my-zsh/custom/plugins/fzf/install
-colorPrint "Install plugins"
-git clone https://github.com/Treri/fzf-zsh.git ~/.oh-my-zsh/custom/plugins/fzf-zsh
-git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/plugins/zsh-autosuggestions
-sed 's,^plugins=(,plugins=(git gitfast mvn fzf-zsh docker last-working-dir colored-man-pages colorize,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-echo "eval \"\$(fasd --init auto zsh-hook zsh-ccomp zsh-ccomp-install zsh-wcomp zsh-wcomp-install)\"" >> ~/.zshrc
-# Add aliases
-colorPrint "Set Aliases"
-echo "export ZSH=~/.oh-my-zsh"  >> ~/.zshrc
-echo "export EDITOR=micro" >> ~/.zshrc
-echo "alias fh=\"find . -name\"" >> ~/.zshrc
-echo "alias t=\"tree -C -h\"" >> ~/.zshrc
-echo "alias m=\"micro\"" >> ~/.zshrc
-echo "alias l=\"exa -luabgU --git --time-style default -s type\"" >> ~/.zshrc
-echo "alias c=\"fasd_cd -d\"" >> ~/.zshrc
-echo "alias mm=\"fasd -e micro --f\"" >> ~/.zshrc
-echo "alias mmm\"fasd -e micro -i\"" >> ~/.zshrc
-colorPrint "Changing Shell (admin)"
-chsh -s $(which zsh)
+# ── Step functions ────────────────────────────────────────────────────────────
+
+backupZshrc() {
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+    warn "Existing ~/.zshrc found — backing up to ~/.zshrc.backup"
+    mv ~/.zshrc ~/.zshrc.backup
+  fi
+}
+
+installPackages() {
+  info "Updating package list"
+  sudo apt-get update -y
+
+  info "Installing base packages via apt"
+  sudo apt-get install -y git zsh tree fzf ripgrep
+
+  # bat is named batcat on Ubuntu due to naming conflict; create a symlink
+  sudo apt-get install -y bat
+  if command -v batcat &>/dev/null && ! command -v bat &>/dev/null; then
+    sudo ln -sf "$(which batcat)" /usr/local/bin/bat
+  fi
+
+  # fd is named fd-find on Ubuntu due to naming conflict; create a symlink
+  sudo apt-get install -y fd-find
+  if command -v fdfind &>/dev/null && ! command -v fd &>/dev/null; then
+    sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+  fi
+
+  # micro editor
+  info "Installing micro"
+  curl https://getmic.ro | bash
+  sudo mv micro /usr/local/bin/micro
+  success "micro installed"
+
+  # eza — modern ls (maintained fork of archived exa)
+  info "Installing eza"
+  sudo mkdir -p /etc/apt/keyrings
+  wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" \
+    | sudo tee /etc/apt/sources.list.d/gierens.list
+  sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+  sudo apt-get update -y
+  sudo apt-get install -y eza
+  success "eza installed"
+
+  # zoxide — smart cd replacement for fasd
+  info "Installing zoxide"
+  curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+  sudo mv ~/.local/bin/zoxide /usr/local/bin/zoxide 2>/dev/null || true
+  success "zoxide installed"
+}
+
+installOhMyZsh() {
+  export ZSH="$HOME/.oh-my-zsh"
+  info "Installing oh-my-zsh"
+  RUNZSH=no CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  success "oh-my-zsh installed"
+}
+
+installPlugins() {
+  local target="${ZSH}/custom/plugins/zsh-autosuggestions"
+  if [[ -d "$target" ]]; then
+    warn "zsh-autosuggestions already cloned — skipping"
+  else
+    info "Cloning zsh-autosuggestions"
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$target"
+    success "zsh-autosuggestions cloned"
+  fi
+}
+
+configureZshrc() {
+  info "Setting theme to muse"
+  sed 's,ZSH_THEME=[^;]*,ZSH_THEME="muse",' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Setting plugins"
+  sed 's,^plugins=(.*,plugins=(git fzf zoxide zsh-autosuggestions colored-man-pages colorize last-working-dir),' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Appending custom config"
+  cat >> ~/.zshrc << 'ZSHRC_EOF'
+
+# ── Custom config ─────────────────────────────────────────────────────────────
+
+export ZSH="$HOME/.oh-my-zsh"
+export EDITOR=micro
+
+alias fh='find . -name'
+alias t='tree -C -h'
+alias m='micro'
+alias l='eza -luabgU --git --time-style=relative -s type'
+alias c='z'
+alias mm='micro "$(fzf --preview="bat --color=always {}")"'
+alias mmm='micro "$(fd --type f | fzf --preview="bat --color=always {}")"'
+ZSHRC_EOF
+
+  success ".zshrc configured"
+}
+
+changeDefaultShell() {
+  if [[ "$(basename "$SHELL")" == "zsh" ]]; then
+    info "zsh is already the default shell — skipping"
+  else
+    info "Changing default shell to zsh (may prompt for password)"
+    chsh -s "$(which zsh)"
+    success "Default shell changed to zsh"
+  fi
+}
+
+verify() {
+  printf "\n${BOLD}── Verification ───────────────────────────────────────────${NORMAL}\n"
+  local pass=0 fail=0
+  check_cmd() {
+    if command -v "$1" &>/dev/null; then
+      success "$1"
+      ((pass++))
+    else
+      error "$1 not found"
+      ((fail++))
+    fi
+  }
+  check_cmd zsh; check_cmd eza; check_cmd zoxide; check_cmd fzf
+  check_cmd micro; check_cmd bat; check_cmd fd; check_cmd rg
+
+  [[ -d "$HOME/.oh-my-zsh" ]] && { success "oh-my-zsh exists"; ((pass++)); } || { error "oh-my-zsh missing"; ((fail++)); }
+  [[ -d "${ZSH}/custom/plugins/zsh-autosuggestions" ]] && { success "zsh-autosuggestions cloned"; ((pass++)); } || { error "zsh-autosuggestions missing"; ((fail++)); }
+
+  printf "\n${BOLD}%d passed, %d failed${NORMAL}\n" "$pass" "$fail"
+  printf "\n${BOLD}Run: exec zsh${NORMAL} to apply all changes\n"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+colorSetup
+printf "\n${BOLD}── zsh-config-bundle installer (Ubuntu) ────────────────────${NORMAL}\n\n"
+
+backupZshrc
+installPackages
+installOhMyZsh
+installPlugins
+configureZshrc
+changeDefaultShell
+verify

--- a/installUbuntuSilent.sh
+++ b/installUbuntuSilent.sh
@@ -1,12 +1,13 @@
-#!/bin/sh
-colorPrint(){
-    printf "${BLUE}"
-    echo "$1"
-    printf "${NORMAL}"
-}
-colorSetup(){
-      if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
+#!/bin/bash
+# Silent version: does NOT change the default shell (no chsh password prompt).
+# All other behaviour is identical to installUbuntu.sh.
+set -e
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+
+colorSetup() {
+  if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
   fi
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
     RED="$(tput setaf 1)"
@@ -16,77 +17,136 @@ colorSetup(){
     BOLD="$(tput bold)"
     NORMAL="$(tput sgr0)"
   else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    BOLD=""
-    NORMAL=""
+    RED="" GREEN="" YELLOW="" BLUE="" BOLD="" NORMAL=""
   fi
 }
 
-colorSetup
-colorPrint "Backing up zshrc"
-if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ~/.zshrc.backup${NORMAL}\n";
-    mv ~/.zshrc ~/.zshrc.backup;
-fi
-# Install Brew
-# Install apps
-colorPrint "Installing Git ..."
-sudo apt-get -y install git
-colorPrint "Installing ZSH ..."
-sudo apt-get -y install zsh
-colorPrint "Installing tree ..."
-sudo apt-get -y install tree
-colorPrint "Installing exa ..."
-curl -Lo exa.zip "https://github.com/ogham/exa/releases/download/v0.8.0/exa-linux-x86_64-0.8.0.zip"
-unzip -o exa.zip -d "./"
-rm -f exa.zip
-sudo mv exa-linux-x86_64 /usr/bin/exa
-rm -rf exa-linux-x86_64
-colorPrint "Installing fasd ..."
-curl -Lo fasd.zip "https://github.com/clvv/fasd/zipball/1.0.1"
-unzip -o fasd.zip -d "./"
-rm -f fasd.zip
-sudo mv clvv-fasd-4822024/fasd /usr/bin/fasd
-rm -rf clvv-fasd-4822024
-colorPrint "Installing micro ..."
-curl https://getmic.ro | bash
-sudo mv micro /usr/bin/micro
+info()    { printf "${BLUE}  →  %s${NORMAL}\n" "$1"; }
+success() { printf "${GREEN}  ✓  %s${NORMAL}\n" "$1"; }
+warn()    { printf "${YELLOW}  !  %s${NORMAL}\n" "$1"; }
+error()   { printf "${RED}  ✗  %s${NORMAL}\n" "$1" >&2; }
 
-#$(brew --prefix)/opt/fzf/install < dev/null
-# Install oh-my-zsh
-colorPrint "Installing oh-my-zsh ..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" < /dev/null
-export ZSH=~/.oh-my-zsh
-cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
-# Set Theme
-colorPrint "Setting Theme"
-sed 's,ZSH_THEME=[^;]*,ZSH_THEME=muse,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-# Add plugins
-colorPrint "Installing fzf ..."
-git clone https://github.com/junegunn/fzf.git ~/.oh-my-zsh/custom/plugins/fzf
-~/.oh-my-zsh/custom/plugins/fzf/install
-colorPrint "Install plugins"
-git clone https://github.com/Treri/fzf-zsh.git ~/.oh-my-zsh/custom/plugins/fzf-zsh
-git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/plugins/zsh-autosuggestions
-sed 's,^plugins=(,plugins=(git gitfast mvn fzf-zsh docker last-working-dir colored-man-pages colorize,' ~/.zshrc > ~/tempfilezshrc
-cp ~/tempfilezshrc ~/.zshrc
-rm ~/tempfilezshrc
-echo "eval \"\$(fasd --init auto zsh-hook zsh-ccomp zsh-ccomp-install zsh-wcomp zsh-wcomp-install)\"" >> ~/.zshrc
-# Add aliases
-colorPrint "Set Aliases"
-echo "export ZSH=~/.oh-my-zsh"  >> ~/.zshrc
-echo "export EDITOR=micro" >> ~/.zshrc
-echo "alias fh=\"find . -name\"" >> ~/.zshrc
-echo "alias t=\"tree -C -h\"" >> ~/.zshrc
-echo "alias m=\"micro\"" >> ~/.zshrc
-echo "alias l=\"exa -luabgU --git --time-style default -s type\"" >> ~/.zshrc
-echo "alias c=\"fasd_cd -d\"" >> ~/.zshrc
-echo "alias mm=\"fasd -e micro --f\"" >> ~/.zshrc
-echo "alias mmm\"fasd -e micro -i\"" >> ~/.zshrc
-#colorPrint "Changing Shell (admin)"
-#chsh -s $(which zsh)
+# ── Step functions ────────────────────────────────────────────────────────────
+
+backupZshrc() {
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+    warn "Existing ~/.zshrc found — backing up to ~/.zshrc.backup"
+    mv ~/.zshrc ~/.zshrc.backup
+  fi
+}
+
+installPackages() {
+  info "Updating package list"
+  sudo apt-get update -y
+
+  info "Installing base packages via apt"
+  sudo apt-get install -y git zsh tree fzf ripgrep
+
+  sudo apt-get install -y bat
+  if command -v batcat &>/dev/null && ! command -v bat &>/dev/null; then
+    sudo ln -sf "$(which batcat)" /usr/local/bin/bat
+  fi
+
+  sudo apt-get install -y fd-find
+  if command -v fdfind &>/dev/null && ! command -v fd &>/dev/null; then
+    sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+  fi
+
+  info "Installing micro"
+  curl https://getmic.ro | bash
+  sudo mv micro /usr/local/bin/micro
+  success "micro installed"
+
+  info "Installing eza"
+  sudo mkdir -p /etc/apt/keyrings
+  wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" \
+    | sudo tee /etc/apt/sources.list.d/gierens.list
+  sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+  sudo apt-get update -y
+  sudo apt-get install -y eza
+  success "eza installed"
+
+  info "Installing zoxide"
+  curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+  sudo mv ~/.local/bin/zoxide /usr/local/bin/zoxide 2>/dev/null || true
+  success "zoxide installed"
+}
+
+installOhMyZsh() {
+  export ZSH="$HOME/.oh-my-zsh"
+  info "Installing oh-my-zsh"
+  RUNZSH=no CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  success "oh-my-zsh installed"
+}
+
+installPlugins() {
+  local target="${ZSH}/custom/plugins/zsh-autosuggestions"
+  if [[ -d "$target" ]]; then
+    warn "zsh-autosuggestions already cloned — skipping"
+  else
+    info "Cloning zsh-autosuggestions"
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$target"
+    success "zsh-autosuggestions cloned"
+  fi
+}
+
+configureZshrc() {
+  info "Setting theme to muse"
+  sed 's,ZSH_THEME=[^;]*,ZSH_THEME="muse",' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Setting plugins"
+  sed 's,^plugins=(.*,plugins=(git fzf zoxide zsh-autosuggestions colored-man-pages colorize last-working-dir),' ~/.zshrc > ~/tempfilezshrc
+  mv ~/tempfilezshrc ~/.zshrc
+
+  info "Appending custom config"
+  cat >> ~/.zshrc << 'ZSHRC_EOF'
+
+# ── Custom config ─────────────────────────────────────────────────────────────
+
+export ZSH="$HOME/.oh-my-zsh"
+export EDITOR=micro
+
+alias fh='find . -name'
+alias t='tree -C -h'
+alias m='micro'
+alias l='eza -luabgU --git --time-style=relative -s type'
+alias c='z'
+alias mm='micro "$(fzf --preview="bat --color=always {}")"'
+alias mmm='micro "$(fd --type f | fzf --preview="bat --color=always {}")"'
+ZSHRC_EOF
+
+  success ".zshrc configured"
+}
+
+verify() {
+  printf "\n${BOLD}── Verification ───────────────────────────────────────────${NORMAL}\n"
+  local pass=0 fail=0
+  check_cmd() {
+    if command -v "$1" &>/dev/null; then success "$1"; ((pass++))
+    else error "$1 not found"; ((fail++)); fi
+  }
+  check_cmd zsh; check_cmd eza; check_cmd zoxide; check_cmd fzf
+  check_cmd micro; check_cmd bat; check_cmd fd; check_cmd rg
+
+  [[ -d "$HOME/.oh-my-zsh" ]] && { success "oh-my-zsh exists"; ((pass++)); } || { error "oh-my-zsh missing"; ((fail++)); }
+  [[ -d "${ZSH}/custom/plugins/zsh-autosuggestions" ]] && { success "zsh-autosuggestions cloned"; ((pass++)); } || { error "zsh-autosuggestions missing"; ((fail++)); }
+
+  printf "\n${BOLD}%d passed, %d failed${NORMAL}\n" "$pass" "$fail"
+  warn "Default shell was NOT changed (silent mode). Run: chsh -s \$(which zsh)"
+  printf "${BOLD}Then run: exec zsh${NORMAL} to apply all changes\n"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+colorSetup
+printf "\n${BOLD}── zsh-config-bundle installer (Ubuntu silent) ─────────────${NORMAL}\n\n"
+
+backupZshrc
+installPackages
+installOhMyZsh
+installPlugins
+configureZshrc
+verify


### PR DESCRIPTION
Replace deprecated/abandoned tools across all platform scripts (Mac, Ubuntu, Ubuntu silent, Arch):
- exa (archived) → eza
- fasd (last release 2012) → zoxide
- fzf-zsh Treri wrapper (broken) → oh-my-zsh built-in fzf plugin

Add bat, fd, ripgrep — complement fzf and power the new mm/mmm aliases.

Fix longstanding bugs: invalid `EDITOR = micro` export, missing `=` in mmm alias, zsh-autosuggestions cloned to wrong directory, old robbyrussell oh-my-zsh URL, deprecated Homebrew install URL, `#!/bin/sh` shebang with bash-only syntax.

Restructure all scripts: #!/bin/bash + set -e, named functions, colour progress output, idempotency guards, and a verify step at the end.

Rewrite README: add title, fix broken screenshot URL, add key bindings table, requirements section, document Ubuntu silent variant, fix install commands from sh -c → bash -c.